### PR TITLE
Circle/triangle ratio settings. Closes #18

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -33,6 +33,27 @@ body {
   display: flex;
 }
 
+.settings-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.range-container {
+  display: flex;
+}
+
+.display-range-container {
+  display: flex;
+  align-items: center;
+}
+
+#reset-ratio {
+  margin-left: 10px;
+  cursor: pointer;
+  color: #007bff;
+}
+
 .container {
   width: 45rem;
   max-width: 100%;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,16 +2,41 @@ const $canvas = document.querySelector("#genetic-canvas");
 const $image = document.getElementById("genetic-image");
 const $matchSpan = document.querySelector("#match_percentage");
 const $genSpan = document.querySelector("#gen_count");
+const $probabilityInput = document.getElementById("probability-input");
+const $probabilityDisplay = document.getElementById("probability-display");
+const $resetRatioBtn = document.getElementById("reset-ratio");
 
 const ctx = $canvas.getContext("2d");
 const helpCanvas = document.createElement("canvas");
 const helpContext = helpCanvas.getContext("2d");
 
+const refreshSlider = () => {
+  $probabilityDisplay.innerText = `◯/△ ratio: ${circleRatio * 100}%`;
+  $probabilityInput.value = circleRatio * 100; 
+}
+
 let mainImageData = null;
+let circleRatio = localStorage.getItem('ratio') ?? 0.5;
+refreshSlider();
 
 $image.addEventListener('load', () => {
   handleLoad($image);
 });
+
+$probabilityInput.addEventListener('change', (value) => {
+  circleRatio = value.target.value / 100;
+  setSlider();
+});
+
+$resetRatioBtn.addEventListener('click', () => {
+  circleRatio = 0.5;
+  setSlider();
+});
+
+const setSlider = () => {
+  localStorage.setItem('ratio', circleRatio);
+  refreshSlider();
+}
 
 $image.src = './assets/img/sunflower.jpg'
 
@@ -142,7 +167,7 @@ function genetic() {
     for (let i = 0; i < olds.length; i++) {
       helpContext.putImageData(olds[i].imageData, 0, 0);
       const color = getRandomColor();
-      if (Math.random() < 0.5) {
+      if (Math.random() < circleRatio) {
         drawCircle(
           helpContext,
           color,

--- a/index.html
+++ b/index.html
@@ -22,6 +22,19 @@
 		<p>Generation: <span id="gen_count"></span></p>
 	</div>
 	<div class="container">
+		<div class="settings-container">
+			<div class="range-container">
+				<span>Draw more △</span>
+				<input type="range" id="probability-input" min="0" max="100">
+				<span>Draw more ◯</span>
+			</div>
+			<div class="display-range-container">
+				<p id="probability-display"></p>
+				<p id="reset-ratio">reset</p>
+			</div>
+		</div>
+	</div>
+	<div class="container">
 		<div class="dropzone" id="dropzone">
 			<label for="files" class="dropzone-container">
 				<div class="file-icon">+</div>


### PR DESCRIPTION
Ability to set circle/triangle ratio by handy slider. Current setup is stored in localStorage and can be also easily reset to default 50%.

![image](https://user-images.githubusercontent.com/10351299/137506195-28791f05-4e8c-4f77-a3bb-dac7bc0a5136.png)
